### PR TITLE
TLS support for TCPSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ var log = new LoggerConfiguration()
 var urlLogger = new LoggerConfiguration()
     .WriteTo.TCPSink("some.url.com", 1337)
     .CreateLogger();
+
+var urlLogger = new LoggerConfiguration()
+    .WriteTo.TCPSink("tls://some.fqdn.com:12435")
+    .CreateLogger();
 ```
 
 Or maybe UDP

--- a/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
+++ b/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
@@ -48,11 +48,20 @@ namespace Serilog.Sinks.Network
 
         public static LoggerConfiguration TCPSink(
             this LoggerSinkConfiguration loggerConfiguration,
-            string uri,
+            string host,
             int port,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
-            var sink = new TCPSink(ResolveAddress(uri), port);
+            var sink = new TCPSink(BuildUri(string.Format("{0}:{1}", host, port)));
+            return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration TCPSink(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string uri,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+            var sink = new TCPSink(BuildUri(uri));
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
 
@@ -86,6 +95,21 @@ namespace Serilog.Sinks.Network
                 SelfLog.WriteLine("Could not resolve " + uri);
                 return null;
             }
+        }
+
+        static Uri BuildUri(string s)
+        {
+            Uri uri;
+            try {
+                uri = new Uri(s);
+            } catch (UriFormatException ex) {
+                throw new ArgumentNullException("Uri should be in the format tcp://server:port", ex);
+            }
+            if (uri.Port == 0)
+                throw new UriFormatException("Uri port cannot be 0");
+            if (!(uri.Scheme.ToLower() == "tcp" || uri.Scheme.ToLower() == "tls"))
+                throw new UriFormatException("Uri scheme must be tcp or tls");
+            return uri;
         }
     }
 }

--- a/Serilog.Sinks.Network/Sinks/TCP/TCPSink.cs
+++ b/Serilog.Sinks.Network/Sinks/TCP/TCPSink.cs
@@ -16,7 +16,13 @@ namespace Serilog.Sinks.Network.Sinks.TCP
 
     public TCPSink(IPAddress ipAddress, int port)
     {
-      _socketWriter = new TcpSocketWriter(new IPEndPoint(ipAddress, port));
+      _socketWriter = new TcpSocketWriter(new Uri(string.Format("tcp://{0}:{1}", ipAddress.ToString(), port)));
+      _formatter = new LogstashJsonFormatter();
+    }
+
+    public TCPSink(Uri uri)
+    {
+      _socketWriter = new TcpSocketWriter(uri);
       _formatter = new LogstashJsonFormatter();
     }
 

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,5 +1,5 @@
 
-semver = '1.0.3'
+semver = '1.1.0'
 
 BUILD_CONFIG = ENV['Configuration'] || 'Release'
 BUILD_NUMBER = ENV['APPVEYOR_BUILD_NUMBER'] || '0'


### PR DESCRIPTION
Hi @pauldambra I am from [Logit.io](https://logit.io), @neeohw is looking to use this Sink with [Logit.io](https://logit.io).

I have taken his great PR and tidied up some aspects to do with configuration.

`NetworkLoggerConfigurationExtensions.ResolveAddress` should not be one time. It will create issues when DNS records are updated. We should rely on the `ExponentialBackoffTcpReconnectionPolicy` and `Socket` to resolve DNS records that are current.

I propose we merge this PR instead, please both let me know your thoughts :)